### PR TITLE
Fixes breaking changes for theme activations

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -11,9 +11,9 @@
             <header class="main-header author-head">
                 <div class="vertical">
                     <div class="main-header-content inner">
-                        {{#if image}}
+                        {{#if profile_image}}
                             <figure class="author-image">
-                                <img class="thumbnail img-circle" src="{{image}}" />
+                                <img class="thumbnail img-circle" src="{{profile_image}}" />
                             </figure>
                         {{/if}}
                         <h1 class="author-title">{{name}}</h1>

--- a/page.hbs
+++ b/page.hbs
@@ -9,8 +9,8 @@
         <main id="content" class="content columns" role="main">
             <article class="{{post_class}}">
                 <header class="post-header">
-                    {{#if image}}
-                        <figure class="image-feature"><img src="{{image}}" /></figure>
+                    {{#if feature_image}}
+                        <figure class="image-feature"><img src="{{feature_image}}" /></figure>
                     {{/if}}
 
                     <div class="post-heading">

--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -4,11 +4,11 @@
 <div class="grid clearfix" id="grid">
 {{#foreach posts}}
     <article class="grid-item">
-        {{#if image}}
+        {{#if cover_image}}
             <div class="cover-image">
                 <a href="{{url}}">
                     <figure class="cover-image-container">
-                        <img src="{{image}}?w=450&q=60" />
+                        <img src="{{cover_image}}?w=450&q=60" />
                     </figure>
                 </a>
             </div>

--- a/post.hbs
+++ b/post.hbs
@@ -10,8 +10,8 @@
             <article class="{{post_class}}">
 
                 <header class="post-header">
-                    {{#if image}}
-                        <figure class="image-feature"><img src="{{image}}" /></figure>
+                    {{#if feature_image}}
+                        <figure class="image-feature"><img src="{{feature_image}}" /></figure>
                     {{/if}}
 
                     <div class="post-heading">


### PR DESCRIPTION
Refer to [Breaking changes for theme activations](https://dev.ghost.org/ghost-1-0-0-rc-1/)

While attempting to activate the theme in Ghost 1.0. RC1, errors were thrown to the tune of:

```
[fatal] Usage of {{image}}, please use {{feature_image}}, {{cover_image}} or {{profile_image}} 
```