### PR TITLE
Fix Disqus PAGE_IDENTIFIER

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -86,7 +86,7 @@
             <script>
                 var disqus_config = function () {
                     this.page.url = '{{url absolute="true"}}';  // Replace PAGE_URL with your page's canonical URL variable
-                    this.page.identifier = '{{comment-id}}'; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+                    this.page.identifier = '{{comment_id}}'; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
                 };
 
                 (function() { // DON'T EDIT BELOW THIS LINE


### PR DESCRIPTION
comment-id variable doesn't exist but comment_id does: https://themes.ghost.org/docs/post-context